### PR TITLE
[Hotfix]: Fix Port Being Required In Cypress

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,8 @@
-import { getRequiredEnv, toInteger } from '@fullstacksjs/toolbox';
+import { getEnv, toInteger } from '@fullstacksjs/toolbox';
 import { defineConfig } from 'cypress';
 
-const port = toInteger(getRequiredEnv('PORT'), 3000);
+const port = toInteger(getEnv('PORT', ''), 3000);
+
 export default defineConfig({
   e2e: {
     baseUrl: `http://127.0.0.1:${port}`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: toInteger(getEnv('PORT', '3000'), 3000),
+    port: toInteger(getEnv('PORT', ''), 3000),
     host: getEnv('HOST'),
     proxy: {
       '/graphql': {


### PR DESCRIPTION
The port env is required in cypress config and won't let cypress run without specifying it.